### PR TITLE
Update kotlin 1.3.40

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.3.31"
+    id "org.jetbrains.kotlin.jvm" version "1.3.40"
 }
 
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.3.21"
+    id "org.jetbrains.kotlin.jvm" version "1.3.31"
 }
 
 
@@ -14,6 +14,6 @@ dependencies {
     testImplementation("junit:junit:4.12")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    implementation("com.android.tools.build:gradle:3.3.1")
-    implementation("com.moowork.gradle:gradle-node-plugin:1.2.0")
+    implementation("com.android.tools.build:gradle:3.4.1")
+    implementation("com.moowork.gradle:gradle-node-plugin:1.3.1")
 }

--- a/buildSrc/src/main/kotlin/com/soywiz/korlibs/targets/Android.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korlibs/targets/Android.kt
@@ -7,10 +7,10 @@ fun Project.configureTargetAndroid() {
     if (korlibs.hasAndroid) {
         plugins.apply("com.android.library")
         extensions.getByType(com.android.build.gradle.LibraryExtension::class.java).apply {
-            compileSdkVersion(28)
+            compileSdkVersion(29)
             defaultConfig {
                 it.minSdkVersion(18)
-                it.targetSdkVersion(28)
+                it.targetSdkVersion(29)
             }
         }
 

--- a/buildSrc/src/main/kotlin/com/soywiz/korlibs/targets/JavaScript.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korlibs/targets/JavaScript.kt
@@ -146,7 +146,7 @@ fun Project.configureTargetJavaScript() {
 
     // Include resources from JS and Metadata (common) into the JS JAR
     val jsJar = tasks.getByName("jsJar") as Jar
-    val jsTest = tasks.getByName("jsTest") as Test
+    val jsTest = tasks.getByName("jsTest")
 
     for (target in listOf(kotlin.targets.js, kotlin.targets.metadata)) {
         //for (target in listOf(kotlin.targets.js)) {

--- a/buildSrc/src/main/kotlin/com/soywiz/korlibs/targets/Native.kt
+++ b/buildSrc/src/main/kotlin/com/soywiz/korlibs/targets/Native.kt
@@ -1,10 +1,10 @@
 package com.soywiz.korlibs.targets
 
-import com.soywiz.korlibs.*
-import org.apache.tools.ant.taskdefs.condition.*
-import org.gradle.api.*
-import org.gradle.api.tasks.*
-import java.io.*
+import com.soywiz.korlibs.gkotlin
+import com.soywiz.korlibs.hasAndroid
+import com.soywiz.korlibs.tasks
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.Project
 
 fun Project.configureTargetNative() {
     gkotlin.apply {
@@ -58,35 +58,9 @@ fun Project.configureTargetNative() {
 
     afterEvaluate {
         for (target in listOf("macosX64", "linuxX64", "mingwX64")) {
-            val taskName = "copyResourcesToExecutable_$target"
-            val targetTestTask = tasks.getByName("${target}Test") as Exec
-            val compileTestTask = tasks.getByName("compileTestKotlin${target.capitalize()}")
-            val compileMainask = tasks.getByName("compileKotlin${target.capitalize()}")
-
             tasks {
-                create<Copy>(taskName) {
-                    for (sourceSet in gkotlin.sourceSets) {
-                        from(sourceSet.resources)
-                    }
-
-                    into(File(targetTestTask.executable).parentFile)
-                }
+                tasks.getByName("${target}Test")
             }
-
-            val reportFile = buildDir["test-results/nativeTest/text/output.txt"].apply { parentFile.mkdirs() }
-            val fout = ByteArrayOutputStream()
-            targetTestTask.standardOutput = MultiOutputStream(listOf(targetTestTask.standardOutput, fout))
-            targetTestTask.doLast {
-                reportFile.writeBytes(fout.toByteArray())
-            }
-
-            targetTestTask.inputs.files(
-                *compileTestTask.outputs.files.files.toTypedArray(),
-                *compileMainask.outputs.files.files.toTypedArray()
-            )
-            targetTestTask.outputs.file(reportFile)
-
-            targetTestTask.dependsOn(taskName)
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Apr 17 14:04:16 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
I just made a PR for updating to kotlin 1.3.31 too.. I would've only made this PR, but I had some issues updating the project.

Looks like there are updates to running multiplatform tests in kotlin 1.3.40.
I think it allows your configureTargetNative configuration to be simplified?

When I build the project on mac: jvm and maxosx64 tests are run at least... but I am not exactly sure I removed other configurations you needed.

The main issue I had when updating to 1.3.40 was that
`val targetTestTask = tasks.getByName("${target}Test") as Exec` failed since `tasks.getByName(...)` returns `KotlinTestReport_Decorated` now